### PR TITLE
add explicit cast to avoid error

### DIFF
--- a/ofono/drivers/qmimodem/voicecall.c
+++ b/ofono/drivers/qmimodem/voicecall.c
@@ -99,7 +99,7 @@ static void all_call_status_ind(struct qmi_result *result, void *user_data)
 		call->id = call_info.id;
 		call->direction = qmi_to_ofono_direction(call_info.direction);
 
-		if (qmi_to_ofono_status(call_info.state, &call->status)) {
+		if (qmi_to_ofono_status(call_info.state, (int*)&call->status)) {
 			DBG("Ignore call id %d, because can not convert QMI state 0x%x to ofono.",
 			    call_info.id, call_info.state);
 			continue;


### PR DESCRIPTION
It seems the manjaro-arm unstable have new gcc or different default cflags.
```
drivers/qmimodem/voicecall.c: In function ‘all_call_status_ind’: drivers/qmimodem/voicecall.c:102:58: error: passing argument 2 of ‘qmi_to_ofono_status’ from incompatible pointer type [-Wincompatible-pointer-types]
  102 |                 if (qmi_to_ofono_status(call_info.state, &call->status)) {
      |                                                          ^~~~~~~~~~~~~
      |                                                          |
      |                                                          enum ofono_call_status *
In file included from drivers/qmimodem/voicecall.c:38:
drivers/qmimodem/voice.h:92:46: note: expected ‘int *’ but argument is of type ‘enum ofono_call_status *’
   92 | int qmi_to_ofono_status(uint8_t status, int *ret);
      |                                         ~~~~~^~~
make[1]: *** [Makefile:5305: drivers/qmimodem/voicecall.o] Error 1
make[1]: *** Waiting for unfinished jobs....
make: *** [Makefile:3072: all] Error 2
```

It would be probably better to change int* to ofono_call_status, but I wasn't able to do the right include.